### PR TITLE
Use std::string_view for tokens #8

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,5 +56,6 @@
   },
   "C_Cpp.vcFormat.indent.preprocessor": "leftmostColumn",
   "C_Cpp.formatting": "vcFormat",
-  "C_Cpp.dimInactiveRegions": false
+  "C_Cpp.dimInactiveRegions": false,
+  "C_Cpp.default.cppStandard": "c++20"
 }

--- a/build/build.c
+++ b/build/build.c
@@ -1,7 +1,7 @@
 #define NOBUILD_IMPLEMENTATION
 #include "../vendor/nobuild/nobuild.h"
 
-#define CPPFLAGS "-Wall", "-Wextra", "-std=c++17", "-pedantic"
+#define CPPFLAGS "-Wall", "-Wextra", "-std=c++20", "-pedantic"
 #define INC_DPL "-Isrc"
 #define INC_CESTER "-Ivendor/libcester/include"
 
@@ -22,7 +22,7 @@ void run_compiler()
 
 void build_tests()
 {
-    CMD("g++.exe", INC_CESTER, INC_DPL, "-I.", "-Wno-write-strings", "-std=c++17",
+    CMD("g++.exe", INC_CESTER, INC_DPL, "-I.", "-Wno-write-strings", "-std=c++20",
         "-o", "tests.exe", SRC_DPL, SRC_TEST);
 }
 

--- a/src/dpl/lexer/Lexer.hpp
+++ b/src/dpl/lexer/Lexer.hpp
@@ -101,7 +101,8 @@ namespace dpl::lexer
 
     Token Lexer::endToken(TokenType type)
     {
-        return Token(startLocation(), type, startPosition, position);
+        return Token(startLocation(), type,
+            std::string_view(startPosition, position));
     }
 
     char Lexer::peek()

--- a/src/dpl/lexer/Token.hpp
+++ b/src/dpl/lexer/Token.hpp
@@ -2,6 +2,7 @@
 #define __DPL_LEXER_TOKEN_H
 
 #include <iostream>
+#include <string_view>
 #include <vector>
 
 #include <dpl/lexer/Location.hpp>
@@ -14,16 +15,13 @@ namespace dpl::lexer
         Location location;
         TokenType type;
 
-        std::string::const_iterator textBegin;
-        std::string::const_iterator textEnd;
+        std::string_view text;
 
         Token();
-        Token(const Location location,
-            TokenType type, std::string::const_iterator textBegin, std::string::const_iterator textEnd);
+        Token(const Location location, TokenType type, const std::string_view& text);
         Token(const Token& token) = default;
 
         void report(std::ostream& os);
-        std::string toString();
 
         bool isInvalid();
 
@@ -37,15 +35,12 @@ namespace dpl::lexer
 
     Token::Token()
         : location(Token::invalid().location),
-        textBegin(Token::invalid().textBegin),
-        textEnd(Token::invalid().textEnd)
+        text(Token::invalid().text)
     {
     }
 
-    Token::Token(const Location location,
-        TokenType type, std::string::const_iterator textBegin, std::string::const_iterator textEnd)
-        : location(location),
-        type(type), textBegin(textBegin), textEnd(textEnd)
+    Token::Token(const Location location, TokenType type, const std::string_view& text)
+        : location(location), type(type), text(text)
     {
     }
 
@@ -59,7 +54,7 @@ namespace dpl::lexer
         }
 
         os << "^";
-        for (int i = 0; i < textEnd - textBegin - 1; ++i)
+        for (std::size_t i = 0; i < text.length(); ++i)
         {
             os << "~";
         }
@@ -67,17 +62,12 @@ namespace dpl::lexer
         os << std::endl;
     }
 
-    std::string Token::toString()
-    {
-        return std::string(textBegin, textEnd);
-    }
-
     std::ostream& operator<<(std::ostream& os, const Token& token)
     {
         os << token.location << ": " << token.type;
-        if (token.textEnd > token.textBegin)
+        if (!token.text.empty())
         {
-            os << ": '" << std::string(token.textBegin, token.textEnd) << "'";
+            os << ": '" << token.text << "'";
         }
         return os;
     }
@@ -90,7 +80,8 @@ namespace dpl::lexer
     {
         static SourceText text("", "");
         static Location location(&text, text.newLine(text.sourceText().begin()), 0);
-        static Token token(location, TokenType::InvalidToken, text.sourceText().begin(), text.sourceText().end());
+        static Token token(location, TokenType::InvalidToken,
+            std::string_view(text.sourceText()));
         return token;
     }
 

--- a/src/dpl/utils/AstExpressionPrinter.hpp
+++ b/src/dpl/utils/AstExpressionPrinter.hpp
@@ -47,7 +47,7 @@ namespace dpl::utils
 
     void AstExpressionPrinter::visitLiteral(const char*, LiteralNode* node)
     {
-        _stream << node->literal.toString();
+        _stream << node->literal.text;
     }
 
     void AstExpressionPrinter::visitBinaryOperator(const char* name, BinaryOperatorNode* node)

--- a/src/dpl/utils/AstTreePrinter.hpp
+++ b/src/dpl/utils/AstTreePrinter.hpp
@@ -35,7 +35,7 @@ namespace dpl::utils
     {
         _printer.write(label);
         _printer.write(": '");
-        _printer.write(token.toString());
+        _printer.write(token.text);
         _printer.write("' @ ");
         _printer.writeLine(token.location);
     }

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -28,7 +28,7 @@ CESTER_BEFORE_ALL(instance,
     {                                                                     \
         auto __token = lexer.nextToken();                                 \
         assert_token_type(token_type, __token.type);                      \
-        cester_assert_str_equal(token_value, __token.toString().c_str()); \
+        cester_assert_str_equal(token_value, std::string(__token.text).c_str()); \
     } while (false)
 
 #define LEXER_LITERAL_TEST(name, token_type, token_value)          \


### PR DESCRIPTION
This PR introduces std::string_view for the representation of token content. This minimizes the effort for evaluating tokens in later phases. For all of this to work correctly, we need to update the compiler standard to C++20.