### PR TITLE
Update build system #9 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,6 @@ jobs:
           platform: x64
       - name: build everything
         run: |
-          gcc -o .\build.exe .\build\build.c
-          ./build.exe run
-          ./build.exe test
+          gcc -o .\nobuild.exe .\nobuild.c
+          ./nobuild.exe run
+          ./nobuild.exe test

--- a/README.md
+++ b/README.md
@@ -4,16 +4,22 @@ This repository contains the source code for the `Dasd Programming Language`. Th
 
 ## Bootstrapping and building
 
-After checking out the repository and all it's submodules, you can bootstrap the build executable by executing (Windows only):
+After checking out the repository and all its submodules, you can bootstrap the build executable by executing (to date, tested under Windows only):
 
 ```
-$ bootstrap.bat
+$ gcc -o nobuild.exe nobuild.c
 ```
 
 The build process uses [nobuild](https://github.com/tsoding/nobuild), for more information, see there.
 
-After the build executable `build.exe` has been created, you can use it to build the compiler itself.
+After the build executable `nobuild.exe` has been created, you can use it to build the compiler itself. It supports the following subcommands:
+
+```
+$ nobuild.exe compile ; Creates dplc
+$ nobuild.exe run     ; Creates dplc and runs it directly
+$ nobuild.exe test    ; Creates the tests executable and  runs it
+```
 
 ## Running
 
-After the compiler has been created, you can simply run it with the command `dplc.exe`. You can build and run the compiler at the same time using the command `build.exe run`.
+After the compiler has been created, you can simply run it with the command `dplc.exe`. You can build and run the compiler at the same time using the command `nobuild.exe run`.

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,1 +1,0 @@
-gcc -o .\build.exe .\build\build.c

--- a/nobuild.c
+++ b/nobuild.c
@@ -1,5 +1,5 @@
 #define NOBUILD_IMPLEMENTATION
-#include "../vendor/nobuild/nobuild.h"
+#include "vendor/nobuild/nobuild.h"
 
 #define CPPFLAGS "-Wall", "-Wextra", "-std=c++20", "-pedantic"
 #define INC_DPL "-Isrc"


### PR DESCRIPTION
This PR changes the build system so that nobuild is used more in its original spirit. That means primarily no operating system specific scripts and correct naming. Also, the README has been updated to reflect these changes.

Close #9.